### PR TITLE
README.pod: ensure the abstract appears on same line as NAME

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -4,9 +4,7 @@
 
 =head1 NAME
 
-L<Novel::Robot::Parser> 
-
-get novel / bbs content from website
+L<Novel::Robot::Parser> - get novel / bbs content from website
 
 小说站点解析引擎
 


### PR DESCRIPTION
This should ensure that the abstract appears in search.cpan.org and metacpan.org search results.